### PR TITLE
feat: add dprStr to Monster schema

### DIFF
--- a/server/monster/Monster.js
+++ b/server/monster/Monster.js
@@ -10,6 +10,7 @@ let monsterSchema = new Schema({
     exp: Number,
     ac: Number,
     dpr: Number,
+    dprStr: String,
     atk: Number,
     sdc: Number,
     userId: String,


### PR DESCRIPTION
Add dprStr to Monster schema so that #d#+# notation can be saved